### PR TITLE
Fix plaid type field names for proper aeson generation

### DIFF
--- a/Data/Api/Types.hs
+++ b/Data/Api/Types.hs
@@ -462,9 +462,9 @@ data PlaidTransactionsGetResponse =
   PlaidTransactionsGetResponse
     { _plaidTransactionsGetResponseAccounts     :: [Account]
     , _plaidTransactionsGetResponseTransactions :: [Transaction]
-    , _plaidTransactionsItem                    :: Item
-    , _plaidTransactionsTotalTransactions       :: Int
-    , _plaidTransactionsRequestId               :: Text
+    , _plaidTransactionsGetResponseItem                    :: Item
+    , _plaidTransactionsGetResponseTotalTransactions       :: Int
+    , _plaidTransactionsGetResponseRequestId               :: Text
     } deriving (Eq, Show)
 
 makeLenses ''PlaidTransactionsGetResponse
@@ -608,9 +608,9 @@ $(deriveJSON (defaultOptions { fieldLabelModifier = quietSnake . drop 9 }) ''Acc
 
 data PlaidIdentityGetResponse =
   PlaidIdentityGetResponse
-    { _plaidIdentityGetResponseAccounts :: [Accounts]
-    , _plaidIdentityGetItem             :: Item
-    , _plaidIdentityGetRequestId        :: Text
+    { _plaidIdentityGetResponseAccounts  :: [Accounts]
+    , _plaidIdentityGetResponseItem      :: Item
+    , _plaidIdentityGetResponseRequestId :: Text
     } deriving (Eq, Show)
 
 makeLenses ''PlaidIdentityGetResponse


### PR DESCRIPTION
On some versions of GHC this fails with a static template-haskell error of  `Non-exhaustive patterns in function toCamel
`

This changes the fields to properly have the prefix that will be dropped from them during th aeson generation avoiding the error though not ensuring the package works as intended (that would be a little more work)

